### PR TITLE
Remove -prof from ghc-prof-options

### DIFF
--- a/graphviz.cabal
+++ b/graphviz.cabal
@@ -112,8 +112,6 @@ Library {
 
         if impl(ghc >= 6.12.1)
            Ghc-Options: -fno-warn-unused-do-bind
-
-        Ghc-Prof-Options:  -prof
 }
 
 Test-Suite graphviz-testsuite {


### PR DESCRIPTION
This is redundant as pointed out by new Cabal versions.