### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/graphviz.cabal
+++ b/graphviz.cabal
@@ -71,7 +71,7 @@ Library {
                            transformers >= 0.2 && < 0.6,
                            text,
                            wl-pprint-text >= 1.1.0.0 && < 1.2.0.0,
-                           dlist >= 0.5 && < 0.8
+                           dlist >= 0.5 && < 0.9
 
         Exposed-Modules:   Data.GraphViz
                            Data.GraphViz.Types


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `graphviz`, but I don't think it will be break anything.