### PR TITLE
Escape slashes in haddock comment

### DIFF
--- a/Data/GraphViz/Types/Monadic.hs
+++ b/Data/GraphViz/Types/Monadic.hs
@@ -175,7 +175,7 @@ convertStatement (ME de)  = DE de
 -- -----------------------------------------------------------------------------
 -- Global Attributes
 
--- | Add graph/sub-graph/cluster attributes.
+-- | Add graph\/sub-graph\/cluster attributes.
 graphAttrs :: Attributes -> Dot n
 graphAttrs = tellStmt . MA . GraphAttrs
 


### PR DESCRIPTION
Haddock is interpreting this as italics instead of showing slash characters.