### PR TITLE
Making 'addNode' an idempotent function, no more exceptions!

### DIFF
--- a/Data/GraphViz/Types/Graph.hs
+++ b/Data/GraphViz/Types/Graph.hs
@@ -279,7 +279,7 @@ addNode n mc as dg = addEmptyCluster mc $ dg { values = ns' }
         NI resClust resAttrs resPreds resSuccs
       where
         resClust = newClust <|> oldClust
-        resAttrs = S.toList $ S.union (S.fromList newAttrs) (S.fromList oldAttrs)
+        resAttrs = unSame $ S.union (toSAttr newAttrs) (toSAttr oldAttrs)
         resPreds = M.unionWith (++) newPreds oldPreds
         resSuccs = M.unionWith (++) newSuccs oldSuccs
 


### PR DESCRIPTION
Throwing an exception when an existing node is added to the "graph" makes recursive construction via the `PrintDot` type class fragile. It seems more intuitive that if a node is already in the graph, it's information should be merged rather than an exception being thrown.