### PR TITLE
replace mapException with handle

### DIFF
--- a/Data/GraphViz/Commands.hs
+++ b/Data/GraphViz/Commands.hs
@@ -249,7 +249,7 @@ runGraphvizCommand :: (PrintDotRepr dg n) => GraphvizCommand -> dg n
                       -> GraphvizOutput -> FilePath
                       -> IO FilePath
 runGraphvizCommand cmd gr t fp
-  = mapException addExc $ graphvizWithHandle cmd gr t toFile
+  = handle (throwIO . addExc) $ graphvizWithHandle cmd gr t toFile
   where
     addFl = (++) ("Unable to create " ++ fp ++ "\n")
     toFile h = SB.hGetContents h >>= SB.writeFile fp >> return fp

--- a/Data/GraphViz/Commands/IO.hs
+++ b/Data/GraphViz/Commands/IO.hs
@@ -149,7 +149,7 @@ runCommand :: (PrintDotRepr dg n)
               -> dg n
               -> IO a
 runCommand cmd args hf dg
-  = mapException notRunnable $
+  = handle (throwIO . notRunnable) $
     withSystemTempFile ("graphviz" <.> "gv") $ \dotFile dotHandle -> do
       finally (hPutCompactDot dotHandle dg) (hClose dotHandle)
       bracket
@@ -189,7 +189,7 @@ runCommand cmd args hf dg
                     ]
 
     -- Augmenting the hf function to let it work within the forkIO:
-    hf' = mapException fErr . hf
+    hf' = handle (throwIO . fErr) . hf
     fErr :: IOException -> GraphvizException
     fErr e = GVProgramExc $ "Error re-directing the output from "
              ++ cmd ++ ": " ++ show e

--- a/Data/GraphViz/Exception.hs
+++ b/Data/GraphViz/Exception.hs
@@ -11,6 +11,7 @@ module Data.GraphViz.Exception
          -- * Re-exported for convenience.
        , mapException
        , throw
+       , throwIO
        , handle
        , bracket
        ) where


### PR DESCRIPTION
`runGraphviz` and related functions seem to throw `IOException` instead of `GraphvizException` when dot executable is missing. I think this happens because `mapException` is only indented to handle  imprecise exceptions:

```
data ExceptionA = ExceptionA
    deriving (Show, Typeable, Exception)

data ExceptionB = ExceptionB
    deriving (Show, Typeable, Exception)

reify :: ExceptionA -> ExceptionB
reify ExceptionA = ExceptionB

mapException reify $ throwIO ExceptionA
  -> throws ExceptionA

mapException reify $ throw ExceptionA
  -> throws ExceptionB

mapException reify $ ((throw ExceptionA) :: IO ())
  -> throws ExceptionB
```

In this pr I use `handle` instead.

Btw, thanks for this library!