### PR TITLE
allow `bytestring-0.11`, `fgl-5.8`, `hspec-2.10`

### DIFF
--- a/graphviz.cabal
+++ b/graphviz.cabal
@@ -67,7 +67,7 @@ Library {
                            fgl >= 5.4 && < 5.8,
                            filepath,
                            polyparse >=1.9 && <1.14,
-                           bytestring >= 0.9 && < 0.11,
+                           bytestring >= 0.9 && < 0.12,
                            colour == 2.3.*,
                            mtl == 2.*,
                            text,

--- a/graphviz.cabal
+++ b/graphviz.cabal
@@ -64,7 +64,7 @@ Library {
                            process,
                            directory,
                            temporary >=1.1 && <1.4,
-                           fgl >= 5.4 && < 5.8,
+                           fgl >= 5.4 && < 5.9,
                            filepath,
                            polyparse >=1.9 && <1.14,
                            bytestring >= 0.9 && < 0.12,

--- a/graphviz.cabal
+++ b/graphviz.cabal
@@ -127,7 +127,7 @@ Test-Suite graphviz-testsuite {
                            fgl >= 5.5.0.0,
                            fgl-arbitrary == 0.2.*,
                            filepath,
-                           hspec >= 2.1 && < 2.8,
+                           hspec >= 2.1 && < 2.11,
                            text,
                            QuickCheck >= 2.3 && < 2.15
         Build-Tool-Depends: hspec-discover:hspec-discover == 2.*


### PR DESCRIPTION
Seems to work fine (including the test suite) with no changes.  
* Updating `bytestring` is necessary to get `graphviz` to build with `base-4.16` (GHC 9.2), because `bytestring-0.10` does not allow `base-4.16` and is unlikely to be updated.
* In addition, the updates to `fgl` and `hspec` are needed to work with `base-4.17` (GHC 9.4).