### PR TITLE
Add PrintDot instances for Word32 and Word64

### DIFF
--- a/Data/GraphViz/Printing.hs
+++ b/Data/GraphViz/Printing.hs
@@ -192,10 +192,10 @@ instance PrintDot Word16 where
   unqtDot = int . fromIntegral
 
 instance PrintDot Word32 where
-  unqtDot = int . fromIntegral
+  unqtDot = unqtDot . toInteger
 
 instance PrintDot Word64 where
-  unqtDot = int . fromIntegral
+  unqtDot = unqtDot . toInteger
 
 instance PrintDot Double where
   -- If it's an "integral" double, then print as an integer.  This

--- a/Data/GraphViz/Printing.hs
+++ b/Data/GraphViz/Printing.hs
@@ -92,7 +92,7 @@ import           Data.Char           (toLower)
 import qualified Data.Set            as Set
 import           Data.String         (IsString(..))
 import           Data.Version        (Version(..))
-import           Data.Word           (Word16, Word8)
+import           Data.Word           (Word64, Word32, Word16, Word8)
 
 #if !(MIN_VERSION_base (4,11,0))
 
@@ -189,6 +189,12 @@ instance PrintDot Word8 where
   unqtDot = int . fromIntegral
 
 instance PrintDot Word16 where
+  unqtDot = int . fromIntegral
+
+instance PrintDot Word32 where
+  unqtDot = int . fromIntegral
+
+instance PrintDot Word64 where
   unqtDot = int . fromIntegral
 
 instance PrintDot Double where


### PR DESCRIPTION
There were already instances for `Word8` and `Word16`. I added the remaining word types.